### PR TITLE
[NUV-16881] fix per compatibilità con Twig 3.x - rimosso utilizzo di metodo @internal 

### DIFF
--- a/Grid/Export/Export.php
+++ b/Grid/Export/Export.php
@@ -13,10 +13,12 @@
 namespace APY\DataGridBundle\Grid\Export;
 
 use APY\DataGridBundle\Grid\Column\ArrayColumn;
+use APY\DataGridBundle\Grid\Grid;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Twig\Template;
+use Twig\TemplateWrapper;
 
 abstract class Export implements ExportInterface, ContainerAwareInterface
 {
@@ -57,7 +59,7 @@ abstract class Export implements ExportInterface, ContainerAwareInterface
      * @param string $charset  Charset of the exported data
      * @param string $role     Security role
      *
-     * @return \APY\DataGridBundle\Grid\Export\Export
+     * @return Export
      */
     public function __construct($title, $fileName = 'export', $params = [], $charset = 'UTF-8', $role = null)
     {
@@ -71,9 +73,9 @@ abstract class Export implements ExportInterface, ContainerAwareInterface
     /**
      * Sets the Container associated with this Controller.
      *
-     * @param ContainerInterface $container A ContainerInterface instance
+     * @param ContainerInterface|null $container A ContainerInterface instance
      *
-     * @return \APY\DataGridBundle\Grid\Export\Export
+     * @return Export
      */
     public function setContainer(ContainerInterface $container = null)
     {
@@ -433,21 +435,21 @@ abstract class Export implements ExportInterface, ContainerAwareInterface
      *
      * @param Template|string $template
      *
-     * @throws \Exception
+     * @return Export
+     *@throws \Exception
      *
-     * @return \APY\DataGridBundle\Grid\Export\Export
      */
     public function setTemplate($template)
     {
         if (is_string($template)) {
             if (substr($template, 0, 8) === '__SELF__') {
                 $this->templates = $this->getTemplatesFromString(substr($template, 8));
-                $this->templates[] = $this->twig->loadTemplate(static::DEFAULT_TEMPLATE);
+                $this->templates[] = $this->twig->load(static::DEFAULT_TEMPLATE);
             } else {
                 $this->templates = $this->getTemplatesFromString($template);
             }
         } elseif ($this->templates === null) {
-            $this->templates[] = $this->twig->loadTemplate(static::DEFAULT_TEMPLATE);
+            $this->templates[] = $this->twig->load(static::DEFAULT_TEMPLATE);
         } else {
             throw new \Exception('Unable to load template');
         }
@@ -458,11 +460,9 @@ abstract class Export implements ExportInterface, ContainerAwareInterface
     protected function getTemplatesFromString($theme)
     {
         $templates = [];
-
-        $template = $this->twig->loadTemplate($theme);
-        while ($template instanceof Template) {
+        $template = $this->twig->load($theme);
+        if ($template instanceof TemplateWrapper) {
             $templates[] = $template;
-            $template = $template->getParent([]);
         }
 
         return $templates;
@@ -664,7 +664,7 @@ abstract class Export implements ExportInterface, ContainerAwareInterface
      * @param $name
      * @param $value
      *
-     * @return \APY\DataGridBundle\Grid\Export\Export
+     * @return Export
      */
     public function addParameter($name, $value)
     {

--- a/Twig/DataGridExtension.php
+++ b/Twig/DataGridExtension.php
@@ -14,19 +14,19 @@ namespace APY\DataGridBundle\Twig;
 
 use APY\DataGridBundle\Grid\Grid;
 use Symfony\Component\Routing\RouterInterface;
-use Twig\Environment;
+use Twig\TemplateWrapper;
 use Twig\Extension\AbstractExtension;
 use Twig\Extension\GlobalsInterface;
-use Twig\Template;
-use Twig\TwigFilter;
+use Twig\Environment;
 use Twig\TwigFunction;
+use Twig\TwigFilter;
 
 class DataGridExtension extends AbstractExtension implements GlobalsInterface
 {
     const DEFAULT_TEMPLATE = '@APYDataGrid/blocks.html.twig';
 
     /**
-     * @var Template[]
+     * @var TemplateWrapper[]
      */
     protected $templates = [];
 
@@ -271,9 +271,9 @@ class DataGridExtension extends AbstractExtension implements GlobalsInterface
     }
 
     /**
-     * @param string                                 $section
-     * @param \APY\DataGridBundle\Grid\Grid          $grid
-     * @param \APY\DataGridBundle\Grid\Column\Column $param
+     * @param string $section
+     * @param Grid   $grid
+     * @param Column $param
      *
      * @return string
      */
@@ -383,7 +383,6 @@ class DataGridExtension extends AbstractExtension implements GlobalsInterface
     protected function hasBlock(Environment $environment, $name)
     {
         foreach ($this->getTemplates($environment) as $template) {
-            /** @var Template $template */
             if ($template->hasBlock($name, [])) {
                 return true;
             }
@@ -399,14 +398,14 @@ class DataGridExtension extends AbstractExtension implements GlobalsInterface
      *
      * @throws \Exception
      *
-     * @return Template[]
+     * @return TemplateWrapper[]
      */
     protected function getTemplates(Environment $environment)
     {
         if (empty($this->templates)) {
-            if ($this->theme instanceof Template) {
+            if ($this->theme instanceof TemplateWrapper) {
                 $this->templates[] = $this->theme;
-                $this->templates[] = $environment->loadTemplate($this->defaultTemplate);
+                $this->templates[] = $environment->load($this->defaultTemplate);
             } elseif (is_string($this->theme)) {
                 $this->templates = $this->getTemplatesFromString($environment, $this->theme);
             } elseif (null === $this->theme) {
@@ -423,17 +422,14 @@ class DataGridExtension extends AbstractExtension implements GlobalsInterface
      * @param Environment $environment
      * @param mixed       $theme
      *
-     * @return Template[]
+     * @return array
      */
     protected function getTemplatesFromString(Environment $environment, $theme)
     {
         $this->templates = [];
 
-        $template = $environment->loadTemplate($theme);
-        while ($template instanceof Template) {
-            $this->templates[] = $template;
-            $template = $template->getParent([]);
-        }
+        $template = $environment->load($theme);
+        $this->templates[] = $template;
 
         return $this->templates;
     }


### PR DESCRIPTION
https://madisoft.atlassian.net/browse/NUV-16881


Per testare questa versione del bundle in Nuvola, eseguire 

`composer require 'apy/datagrid-bundle dev-NUV-16881-aggiornamento-di-twig-alla-versione-3'`